### PR TITLE
Connection pooling & speedup of testsuite

### DIFF
--- a/lib/rom/rethinkdb/commands/create.rb
+++ b/lib/rom/rethinkdb/commands/create.rb
@@ -18,8 +18,7 @@ module ROM
         end
 
         def insert(tuples)
-          pks = dataset.scope.insert(tuples)
-                .run(dataset.connection)["generated_keys"]
+          pks = dataset.insert(tuples).fetch("generated_keys")
 
           dataset.filter { |user| relation.rql.expr(pks).contains(user["id"]) }
             .to_a

--- a/lib/rom/rethinkdb/commands/delete.rb
+++ b/lib/rom/rethinkdb/commands/delete.rb
@@ -9,7 +9,7 @@ module ROM
 
         def execute
           deleted = dataset.to_a
-          dataset.scope.delete.run(dataset.connection)
+          dataset.delete
           deleted
         end
 

--- a/lib/rom/rethinkdb/commands/update.rb
+++ b/lib/rom/rethinkdb/commands/update.rb
@@ -16,7 +16,7 @@ module ROM
         end
 
         def update(tuple)
-          dataset.scope.update(tuple).run(dataset.connection)
+          dataset.update(tuple)
           dataset.to_a
         end
 

--- a/lib/rom/rethinkdb/dataset.rb
+++ b/lib/rom/rethinkdb/dataset.rb
@@ -4,30 +4,42 @@ module ROM
     #
     # @api public
     class Dataset
-      attr_reader :scope, :rql, :connection
+      attr_reader :scope, :rql, :gateway
 
-      def initialize(scope, rql, connection)
+      def initialize(scope, rql, gateway)
         @scope = scope
         @rql = rql
-        @connection = connection
+        @gateway = gateway
       end
 
       def to_a
-        scope.run(connection)
+        gateway.run(scope).to_a
       end
 
       def each(&block)
         to_a.each(&block)
       end
 
+      def insert(tuples)
+        gateway.run(scope.insert(tuples))
+      end
+
+      def delete
+        gateway.run(scope.delete)
+      end
+
+      def update(reql)
+        gateway.run(scope.update(reql))
+      end
+
       def count
-        scope.count.run(connection)
+        gateway.run(scope.count)
       end
 
       [:filter, :pluck, :order_by].each do |method_name|
         define_method(method_name) do |*args, &block|
           self.class.new(scope.send(method_name, *args, &block), rql,
-          connection)
+          gateway)
         end
       end
     end

--- a/rom-rethinkdb.gemspec
+++ b/rom-rethinkdb.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rethinkdb'
   spec.add_runtime_dependency 'rom', '~> 0.9', '>= 0.9.0'
+  spec.add_runtime_dependency 'connection_pool', '>= 0.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -10,7 +10,7 @@ describe 'Commands / Create' do
   subject(:users) { rom.commands.users }
 
   before do
-    create_table('test_db', 'users')
+    create_table('test_db', 'users') unless table_exist?('test_db', 'users')
 
     setup.relation(:users)
 
@@ -41,7 +41,7 @@ describe 'Commands / Create' do
   end
 
   after do
-    drop_table('test_db', 'users')
+    truncate_table('test_db', 'users')
   end
 
   it 'returns a single tuple when result is set to :one' do

--- a/spec/integration/commands/delete_spec.rb
+++ b/spec/integration/commands/delete_spec.rb
@@ -10,7 +10,7 @@ describe 'Commands / Delete' do
   let(:gateway) { rom.gateways[:default] }
 
   before do
-    create_table('test_db', 'users')
+    create_table('test_db', 'users') unless table_exist?('test_db', 'users')
 
     setup.relation(:users) do
       def by_id(id)
@@ -25,16 +25,11 @@ describe 'Commands / Delete' do
     end
 
     # fill table
-    [
-      { name: 'John', street: 'Main Street' }
-    ].each do |data|
-      gateway.send(:rql).table('users').insert(data)
-        .run(gateway.connection)
-    end
+    insert_data('test_db', 'users', { name: 'John', street: 'Main Street' })
   end
 
   after do
-    drop_table('test_db', 'users')
+    truncate_table('test_db', 'users')
   end
 
   it 'deletes all tuples in a restricted relation' do

--- a/spec/integration/commands/update_spec.rb
+++ b/spec/integration/commands/update_spec.rb
@@ -11,7 +11,7 @@ describe 'Commands / Updates' do
   let(:gateway) { rom.gateways[:default] }
 
   before do
-    create_table('test_db', 'users')
+    create_table('test_db', 'users') unless table_exist?('test_db', 'users')
 
     setup.relation(:users) do
       def by_id(id)
@@ -39,16 +39,11 @@ describe 'Commands / Updates' do
     end
 
     # fill table
-    [
-      { name: 'John', street: 'Main Street' }
-    ].each do |data|
-      gateway.send(:rql).table('users').insert(data)
-        .run(gateway.connection)
-    end
+    insert_data('test_db', 'users' , { name: 'John', street: 'Main Street' })
   end
 
   after do
-    drop_table('test_db', 'users')
+    truncate_table('test_db', 'users')
   end
 
   it 'updates everything when there is no original tuple' do

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -10,7 +10,7 @@ describe 'RethinkDB gateway' do
   subject(:rom) { setup.finalize }
 
   before do
-    create_table('test_db', 'users')
+    create_table('test_db', 'users') unless table_exist?('test_db', 'users')
 
     setup.relation(:users) do
       def with_name(name)
@@ -52,18 +52,15 @@ describe 'RethinkDB gateway' do
     end
 
     # fill table
-    [
-      { name: 'John', street: 'Main Street' },
-      { name: 'Joe', street: '2nd Street' },
-      { name: 'Jane', street: 'Main Street' }
-    ].each do |data|
-      gateway.send(:rql).table('users').insert(data)
-        .run(gateway.connection)
-    end
+    insert_data('test_db', 'users', [
+                             { name: 'John', street: 'Main Street' },
+                             { name: 'Joe', street: '2nd Street' },
+                             { name: 'Jane', street: 'Main Street' }
+                         ])
   end
 
   after do
-    drop_table('test_db', 'users')
+    truncate_table('test_db', 'users')
   end
 
   describe 'env#relation' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,12 +15,12 @@ require_relative 'support/prepare_db'
 RSpec.configure do |config|
   config.include PrepareDB
 
-  config.before(:all) do
-    create_database('test_db')
+  config.before(:suite) do
+    PrepareDB.create_database('test_db')
   end
 
-  config.after(:all) do
-    drop_database('test_db')
+  config.after(:suite) do
+    PrepareDB.drop_database('test_db')
   end
 end
 

--- a/spec/support/prepare_db.rb
+++ b/spec/support/prepare_db.rb
@@ -1,4 +1,5 @@
 module PrepareDB
+  extend(self)
   def create_database(database)
     drop_database(database)
 
@@ -26,6 +27,14 @@ module PrepareDB
     if table_exist?(database, table)
       rql.db(database).table_drop(table).run(connection)
     end
+  end
+
+  def insert_data(database, table, data)
+    rql.db(database).table(table).insert(data).run(connection)
+  end
+
+  def truncate_table(database, table)
+    rql.db(database).table(table).delete.run(connection)
   end
 
   def table_exist?(database, table)

--- a/spec/unit/gateway_spec.rb
+++ b/spec/unit/gateway_spec.rb
@@ -14,10 +14,28 @@ describe ROM::RethinkDB::Gateway do
     context 'default values' do
       let(:connection) { gateway.new(uri).connection }
 
+      class FakeQuery
+        def initialize(&block)
+          @block = block
+        end
+
+        def run(connection)
+          @block.call(connection)
+        end
+      end
+
       it 'returns them' do
-        expect(connection.default_db).to eql('database')
-        expect(connection.host).to eql('localhost')
-        expect(connection.port).to eql(28_015)
+        connection_yielded = false
+        query = FakeQuery.new{|connection|
+          expect(connection.default_db).to eql('database')
+          expect(connection.host).to eql('localhost')
+          expect(connection.port).to eql(28_015)
+          connection_yielded = true
+        }
+
+        gateway.new(uri).run(query)
+
+        expect(connection_yielded).to eq(true)
       end
     end
   end


### PR DESCRIPTION
- Connection pooling is handled by the connection_pool gem.
  - in order for connection_pool to do it's job connections need to automatically reconnect, thus auto_reconnect(true) is called on connections
- Gateway is passed to Dataset instead of connection
- Test suite was creating and droping the entire database before/after(:all), this is now done before/after(:suite) instead. On my laptop a full testrun went from 25s to 4s.
