### PR TITLE
Fix dependencies to make tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ before_script:
   - sudo /etc/init.d/rethinkdb restart
 script: "bundle exec rake spec"
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - rbx-2
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+  - rbx
   - jruby-9000
-  - ruby-head
 matrix:
   allow_failures:
-    - rvm: ruby-head
+    - rvm: rbx
+    - rvm: jruby-9000
 notifications:
   webhooks:
     urls:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'rom', github: 'rom-rb/rom', branch: 'master'
 
 group :test do
   gem 'virtus'
-  gem 'activesupport'
   gem 'rspec', '~> 3.1'
   gem 'codeclimate-test-reporter', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rom', github: 'rom-rb/rom', branch: 'master'
+
 group :test do
-  gem 'rom', github: 'rom-rb/rom', branch: 'master'
-  gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
-  gem 'rom-mapper', github: 'rom-rb/rom-mapper', branch: 'master'
   gem 'virtus'
   gem 'activesupport'
   gem 'rspec', '~> 3.1'


### PR DESCRIPTION
Right now tests are not passing with

```
NoMethodError:
   undefined method `gateway' for ROM::Relation[Users]:Class
```

This is probably because of changes in `rom-support`. This PR fixes dependencies to make them like in `rom-sql`, thus fixing tests too.

Also removes ActiveSupport dependency in tests as it's not needed anywhere. And changes `.travis.yml` to match the one in `rom-sql` (+ ignore jruby).